### PR TITLE
Add CSV export and average goal per granularity

### DIFF
--- a/index.html
+++ b/index.html
@@ -952,6 +952,7 @@
                             <label><input type="checkbox" class="type-filter" value="Gula rutan" checked> Gula rutan</label>
                             <label><input type="checkbox" class="type-filter" value="Bolån" checked> Bolån</label>
                             <label><input type="checkbox" class="type-filter" value="totalt" checked> Ärenden totalt</label>
+                            <label><input type="checkbox" class="type-filter" value="mal"> Genomsnittligt mål</label>
                         </div>
                     </div>
                 </div>
@@ -1867,13 +1868,20 @@
                 currentChart.destroy();
             }
 
+            const avgGoal = calculateAverageGoal(granularity);
+            labels.forEach(label => {
+                if (!groupedData[label]) groupedData[label] = {};
+                groupedData[label].mal = Math.round(avgGoal * 10) / 10;
+            });
+
             const datasetConfig = {
                 'Säkra meddelanden': { backgroundColor: 'rgba(46, 125, 50, 0.2)', borderColor: 'rgba(46, 125, 50, 1)' },
                 'Informationsfullmakt': { backgroundColor: 'rgba(156, 39, 176, 0.2)', borderColor: 'rgba(156, 39, 176, 1)' },
                 'Gula rutan': { backgroundColor: 'rgba(255, 193, 7, 0.2)', borderColor: 'rgba(255, 193, 7, 1)' },
                 'Bolån': { backgroundColor: 'rgba(233, 30, 99, 0.2)', borderColor: 'rgba(233, 30, 99, 1)' },
                 'samtal': { label: 'Samtal', backgroundColor: 'rgba(11, 92, 171, 0.2)', borderColor: 'rgba(11, 92, 171, 1)' },
-                'totalt': { label: 'Ärenden totalt', backgroundColor: 'rgba(100, 100, 100, 0.2)', borderColor: 'rgba(100, 100, 100, 1)' }
+                'totalt': { label: 'Ärenden totalt', backgroundColor: 'rgba(100, 100, 100, 0.2)', borderColor: 'rgba(100, 100, 100, 1)' },
+                'mal': { label: 'Genomsnittligt mål', backgroundColor: 'rgba(0,0,0,0)', borderColor: 'rgba(0,0,0,0.8)', borderDash: [5,5] }
             };
 
             const datasets = selectedTypes.map(type => {
@@ -1884,8 +1892,9 @@
                     backgroundColor: config.backgroundColor,
                     borderColor: config.borderColor,
                     borderWidth: 2,
-                    fill: chartType === 'line' ? 'origin' : false,
-                    tension: 0.4
+                    fill: chartType === 'line' && type !== 'mal' ? 'origin' : false,
+                    tension: 0.4,
+                    borderDash: config.borderDash || []
                 };
             });
 
@@ -1993,6 +2002,29 @@
                     return date.toLocaleDateString('sv-SE');
             }
         }
+
+        function calculateAverageGoal(granularity) {
+            const goals = getLocalStorage('ksGoals', DEFAULT_GOALS);
+            const sumGoals = obj => Object.values(obj).reduce((sum, val) => sum + val, 0);
+            switch (granularity) {
+                case 'timme':
+                    return sumGoals(goals.pass || DEFAULT_GOALS.pass) / 8;
+                case 'pass':
+                    return sumGoals(goals.pass || DEFAULT_GOALS.pass);
+                case 'dag':
+                    return sumGoals(goals.vecka || DEFAULT_GOALS.vecka) / 5;
+                case 'vecka':
+                    return sumGoals(goals.vecka || DEFAULT_GOALS.vecka);
+                case 'manad':
+                    return sumGoals(goals.manad || DEFAULT_GOALS.manad);
+                case 'kvartal':
+                    return sumGoals(goals.kvartal || DEFAULT_GOALS.kvartal);
+                case 'ar':
+                    return sumGoals(goals.ar || DEFAULT_GOALS.ar);
+                default:
+                    return 0;
+            }
+        }
         
         function updateTable() {
             const { calls, sales } = filterData();
@@ -2009,7 +2041,8 @@
                 'Informationsfullmakt': 'Informationsfullmakt',
                 'Gula rutan': 'Gula rutan',
                 'Bolån': 'Bolån',
-                'totalt': 'Ärenden totalt'
+                'totalt': 'Ärenden totalt',
+                'mal': 'Genomsnittligt mål'
             };
 
             thead.innerHTML = `<tr><th>${granularity.charAt(0).toUpperCase() + granularity.slice(1)}</th>` +
@@ -2031,6 +2064,12 @@
                     groupedData['Nästa'] = {};
                 }
             }
+
+            const avgGoal = calculateAverageGoal(granularity);
+            labels.forEach(label => {
+                if (!groupedData[label]) groupedData[label] = {};
+                groupedData[label].mal = Math.round(avgGoal * 10) / 10;
+            });
 
             const rows = labels.map(label => {
                 const data = groupedData[label] || {};
@@ -2088,23 +2127,66 @@
         }
         
         function exportAllData() {
-            const data = {
-                ksCalls: getLocalStorage('ksCalls', []),
-                ksSales: getLocalStorage('ksSales', []),
-                ksPass: getLocalStorage('ksPass', []),
-                ksGoals: getLocalStorage('ksGoals', DEFAULT_GOALS),
-                exportDate: new Date().toISOString(),
-                version: '1.0'
+            const calls = getLocalStorage('ksCalls', []);
+            const sales = getLocalStorage('ksSales', []);
+            const goals = getLocalStorage('ksGoals', DEFAULT_GOALS);
+
+            const escape = val => {
+                const str = val !== undefined && val !== null ? String(val) : '';
+                return '"' + str.replace(/"/g, '""') + '"';
             };
-            
-            const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+
+            const lines = [];
+
+            if (calls.length > 0) {
+                lines.push('dataset,typ,kategori,vad_gick_bra,forbattra,stjarna_generellt,stjarna_kund,stjarna_insats,samtalstid_min,timestamp');
+                calls.forEach(c => {
+                    lines.push([
+                        'call',
+                        escape(c.typ),
+                        escape(c.kategori),
+                        escape(c.vad_gick_bra),
+                        escape(c.forbattra),
+                        escape(c.stjarna_generellt),
+                        escape(c.stjarna_kund),
+                        escape(c.stjarna_insats),
+                        escape(c.samtalstid_min),
+                        escape(c.timestamp)
+                    ].join(','));
+                });
+                lines.push('');
+            }
+
+            if (sales.length > 0) {
+                lines.push('dataset,typ,kanal,tagg,timestamp');
+                sales.forEach(s => {
+                    lines.push([
+                        'sale',
+                        escape(s.typ),
+                        escape(s.kanal),
+                        escape(s.tagg),
+                        escape(s.timestamp)
+                    ].join(','));
+                });
+                lines.push('');
+            }
+
+            lines.push('period,typ,mal');
+            Object.entries(goals).forEach(([period, obj]) => {
+                Object.entries(obj).forEach(([t, val]) => {
+                    lines.push([period, t, val].join(','));
+                });
+            });
+
+            const csvContent = lines.join('\n');
+            const blob = new Blob([csvContent], { type: 'text/csv' });
             const url = window.URL.createObjectURL(blob);
             const link = document.createElement('a');
             link.href = url;
-            link.download = `ks-data-${new Date().toISOString().split('T')[0]}.json`;
+            link.download = `ks-data-${new Date().toISOString().split('T')[0]}.csv`;
             link.click();
             window.URL.revokeObjectURL(url);
-            
+
             showToast('All data har exporterats');
         }
         


### PR DESCRIPTION
## Summary
- Support exporting all collected data as CSV instead of JSON
- Allow viewing average goal per selected granularity in charts and tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a84838a054833385589c70b17a4539