### PR TITLE
Show average lines for selected datasets

### DIFF
--- a/index.html
+++ b/index.html
@@ -952,7 +952,6 @@
                             <label><input type="checkbox" class="type-filter" value="Gula rutan" checked> Gula rutan</label>
                             <label><input type="checkbox" class="type-filter" value="Bolån" checked> Bolån</label>
                             <label><input type="checkbox" class="type-filter" value="totalt" checked> Ärenden totalt</label>
-                            <label><input type="checkbox" class="type-filter" value="mal"> Genomsnittligt mål</label>
                         </div>
                     </div>
                 </div>
@@ -1868,34 +1867,43 @@
                 currentChart.destroy();
             }
 
-            const avgGoal = calculateAverageGoal(granularity);
-            labels.forEach(label => {
-                if (!groupedData[label]) groupedData[label] = {};
-                groupedData[label].mal = Math.round(avgGoal * 10) / 10;
-            });
-
             const datasetConfig = {
                 'Säkra meddelanden': { backgroundColor: 'rgba(46, 125, 50, 0.2)', borderColor: 'rgba(46, 125, 50, 1)' },
                 'Informationsfullmakt': { backgroundColor: 'rgba(156, 39, 176, 0.2)', borderColor: 'rgba(156, 39, 176, 1)' },
                 'Gula rutan': { backgroundColor: 'rgba(255, 193, 7, 0.2)', borderColor: 'rgba(255, 193, 7, 1)' },
                 'Bolån': { backgroundColor: 'rgba(233, 30, 99, 0.2)', borderColor: 'rgba(233, 30, 99, 1)' },
                 'samtal': { label: 'Samtal', backgroundColor: 'rgba(11, 92, 171, 0.2)', borderColor: 'rgba(11, 92, 171, 1)' },
-                'totalt': { label: 'Ärenden totalt', backgroundColor: 'rgba(100, 100, 100, 0.2)', borderColor: 'rgba(100, 100, 100, 1)' },
-                'mal': { label: 'Genomsnittligt mål', backgroundColor: 'rgba(0,0,0,0)', borderColor: 'rgba(0,0,0,0.8)', borderDash: [5,5] }
+                'totalt': { label: 'Ärenden totalt', backgroundColor: 'rgba(100, 100, 100, 0.2)', borderColor: 'rgba(100, 100, 100, 1)' }
             };
 
-            const datasets = selectedTypes.map(type => {
+            const datasets = [];
+            selectedTypes.forEach(type => {
                 const config = datasetConfig[type];
-                return {
+                const data = labels.map(label => groupedData[label]?.[type] || 0);
+
+                datasets.push({
                     label: config.label || type,
-                    data: labels.map(label => groupedData[label]?.[type] || 0),
+                    data,
                     backgroundColor: config.backgroundColor,
                     borderColor: config.borderColor,
                     borderWidth: 2,
-                    fill: chartType === 'line' && type !== 'mal' ? 'origin' : false,
+                    fill: chartType === 'line' ? 'origin' : false,
+                    tension: 0.4
+                });
+
+                const sum = data.reduce((acc, val) => acc + val, 0);
+                const avg = data.length ? Math.round((sum / data.length) * 10) / 10 : 0;
+                datasets.push({
+                    label: `Genomsnitt ${config.label || type}`,
+                    data: labels.map(() => avg),
+                    backgroundColor: 'rgba(0,0,0,0)',
+                    borderColor: config.borderColor,
+                    borderWidth: 2,
+                    borderDash: [5, 5],
+                    fill: false,
                     tension: 0.4,
-                    borderDash: config.borderDash || []
-                };
+                    type: 'line'
+                });
             });
 
             currentChart = new Chart(ctx, {
@@ -2003,29 +2011,6 @@
             }
         }
 
-        function calculateAverageGoal(granularity) {
-            const goals = getLocalStorage('ksGoals', DEFAULT_GOALS);
-            const sumGoals = obj => Object.values(obj).reduce((sum, val) => sum + val, 0);
-            switch (granularity) {
-                case 'timme':
-                    return sumGoals(goals.pass || DEFAULT_GOALS.pass) / 8;
-                case 'pass':
-                    return sumGoals(goals.pass || DEFAULT_GOALS.pass);
-                case 'dag':
-                    return sumGoals(goals.vecka || DEFAULT_GOALS.vecka) / 5;
-                case 'vecka':
-                    return sumGoals(goals.vecka || DEFAULT_GOALS.vecka);
-                case 'manad':
-                    return sumGoals(goals.manad || DEFAULT_GOALS.manad);
-                case 'kvartal':
-                    return sumGoals(goals.kvartal || DEFAULT_GOALS.kvartal);
-                case 'ar':
-                    return sumGoals(goals.ar || DEFAULT_GOALS.ar);
-                default:
-                    return 0;
-            }
-        }
-        
         function updateTable() {
             const { calls, sales } = filterData();
             const granularity = document.getElementById('granularity').value;
@@ -2041,8 +2026,7 @@
                 'Informationsfullmakt': 'Informationsfullmakt',
                 'Gula rutan': 'Gula rutan',
                 'Bolån': 'Bolån',
-                'totalt': 'Ärenden totalt',
-                'mal': 'Genomsnittligt mål'
+                'totalt': 'Ärenden totalt'
             };
 
             thead.innerHTML = `<tr><th>${granularity.charAt(0).toUpperCase() + granularity.slice(1)}</th>` +
@@ -2064,12 +2048,6 @@
                     groupedData['Nästa'] = {};
                 }
             }
-
-            const avgGoal = calculateAverageGoal(granularity);
-            labels.forEach(label => {
-                if (!groupedData[label]) groupedData[label] = {};
-                groupedData[label].mal = Math.round(avgGoal * 10) / 10;
-            });
 
             const rows = labels.map(label => {
                 const data = groupedData[label] || {};


### PR DESCRIPTION
## Summary
- remove "Genomsnittligt mål" from the Data to show filter
- draw dashed average lines for each selected dataset in the statistics chart
- drop unused goal averaging code from table generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a84b8cf22883338f36437c23ef9efa