### PR TITLE
Show average counts in statistics graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,6 +536,19 @@
             height: 400px;
             margin-bottom: 2rem;
         }
+
+        .chart-average {
+            position: absolute;
+            top: 0.5rem;
+            left: 0.5rem;
+            background: var(--color-surface);
+            border: 1px solid var(--color-border);
+            border-radius: var(--radius-small);
+            padding: 0.25rem 0.5rem;
+            font-size: 0.875rem;
+            box-shadow: var(--shadow-small);
+            display: none;
+        }
         
         .chart-controls {
             display: flex;
@@ -952,7 +965,6 @@
                             <label><input type="checkbox" class="type-filter" value="Gula rutan" checked> Gula rutan</label>
                             <label><input type="checkbox" class="type-filter" value="Bolån" checked> Bolån</label>
                             <label><input type="checkbox" class="type-filter" value="totalt" checked> Ärenden totalt</label>
-                            <label><input type="checkbox" class="type-filter" value="mal"> Genomsnittligt mål</label>
                         </div>
                     </div>
                 </div>
@@ -984,6 +996,7 @@
                     </div>
                 </div>
                 <div class="chart-container">
+                    <div id="averageBox" class="chart-average"></div>
                     <canvas id="mainChart"></canvas>
                 </div>
             </div>
@@ -1868,20 +1881,13 @@
                 currentChart.destroy();
             }
 
-            const avgGoal = calculateAverageGoal(granularity);
-            labels.forEach(label => {
-                if (!groupedData[label]) groupedData[label] = {};
-                groupedData[label].mal = Math.round(avgGoal * 10) / 10;
-            });
-
             const datasetConfig = {
                 'Säkra meddelanden': { backgroundColor: 'rgba(46, 125, 50, 0.2)', borderColor: 'rgba(46, 125, 50, 1)' },
                 'Informationsfullmakt': { backgroundColor: 'rgba(156, 39, 176, 0.2)', borderColor: 'rgba(156, 39, 176, 1)' },
                 'Gula rutan': { backgroundColor: 'rgba(255, 193, 7, 0.2)', borderColor: 'rgba(255, 193, 7, 1)' },
                 'Bolån': { backgroundColor: 'rgba(233, 30, 99, 0.2)', borderColor: 'rgba(233, 30, 99, 1)' },
                 'samtal': { label: 'Samtal', backgroundColor: 'rgba(11, 92, 171, 0.2)', borderColor: 'rgba(11, 92, 171, 1)' },
-                'totalt': { label: 'Ärenden totalt', backgroundColor: 'rgba(100, 100, 100, 0.2)', borderColor: 'rgba(100, 100, 100, 1)' },
-                'mal': { label: 'Genomsnittligt mål', backgroundColor: 'rgba(0,0,0,0)', borderColor: 'rgba(0,0,0,0.8)', borderDash: [5,5] }
+                'totalt': { label: 'Ärenden totalt', backgroundColor: 'rgba(100, 100, 100, 0.2)', borderColor: 'rgba(100, 100, 100, 1)' }
             };
 
             const datasets = selectedTypes.map(type => {
@@ -1892,11 +1898,35 @@
                     backgroundColor: config.backgroundColor,
                     borderColor: config.borderColor,
                     borderWidth: 2,
-                    fill: chartType === 'line' && type !== 'mal' ? 'origin' : false,
+                    fill: chartType === 'line' ? 'origin' : false,
                     tension: 0.4,
                     borderDash: config.borderDash || []
                 };
             });
+
+            const actualLabels = labels.filter(l => !['Föregående', 'Nästa', 'Inga data'].includes(l));
+            const averages = {};
+            selectedTypes.forEach(type => {
+                const total = actualLabels.reduce((sum, label) => sum + (groupedData[label]?.[type] || 0), 0);
+                let divisor = actualLabels.length;
+                if (granularity === 'timme') {
+                    const range = getDateRange();
+                    if (range) {
+                        const msPerDay = 1000 * 60 * 60 * 24;
+                        const days = Math.floor((range.endDate - range.startDate) / msPerDay) + 1;
+                        divisor = days * 8;
+                    }
+                }
+                averages[type] = total / (divisor || 1);
+            });
+
+            const avgBox = document.getElementById('averageBox');
+            if (selectedTypes.length > 0) {
+                avgBox.innerHTML = selectedTypes.map(type => `${type}: ${averages[type].toFixed(1)} per ${granularity}`).join('<br>');
+                avgBox.style.display = 'block';
+            } else {
+                avgBox.style.display = 'none';
+            }
 
             currentChart = new Chart(ctx, {
                 type: chartType,
@@ -2003,29 +2033,6 @@
             }
         }
 
-        function calculateAverageGoal(granularity) {
-            const goals = getLocalStorage('ksGoals', DEFAULT_GOALS);
-            const sumGoals = obj => Object.values(obj).reduce((sum, val) => sum + val, 0);
-            switch (granularity) {
-                case 'timme':
-                    return sumGoals(goals.pass || DEFAULT_GOALS.pass) / 8;
-                case 'pass':
-                    return sumGoals(goals.pass || DEFAULT_GOALS.pass);
-                case 'dag':
-                    return sumGoals(goals.vecka || DEFAULT_GOALS.vecka) / 5;
-                case 'vecka':
-                    return sumGoals(goals.vecka || DEFAULT_GOALS.vecka);
-                case 'manad':
-                    return sumGoals(goals.manad || DEFAULT_GOALS.manad);
-                case 'kvartal':
-                    return sumGoals(goals.kvartal || DEFAULT_GOALS.kvartal);
-                case 'ar':
-                    return sumGoals(goals.ar || DEFAULT_GOALS.ar);
-                default:
-                    return 0;
-            }
-        }
-        
         function updateTable() {
             const { calls, sales } = filterData();
             const granularity = document.getElementById('granularity').value;
@@ -2041,8 +2048,7 @@
                 'Informationsfullmakt': 'Informationsfullmakt',
                 'Gula rutan': 'Gula rutan',
                 'Bolån': 'Bolån',
-                'totalt': 'Ärenden totalt',
-                'mal': 'Genomsnittligt mål'
+                'totalt': 'Ärenden totalt'
             };
 
             thead.innerHTML = `<tr><th>${granularity.charAt(0).toUpperCase() + granularity.slice(1)}</th>` +
@@ -2064,12 +2070,6 @@
                     groupedData['Nästa'] = {};
                 }
             }
-
-            const avgGoal = calculateAverageGoal(granularity);
-            labels.forEach(label => {
-                if (!groupedData[label]) groupedData[label] = {};
-                groupedData[label].mal = Math.round(avgGoal * 10) / 10;
-            });
 
             const rows = labels.map(label => {
                 const data = groupedData[label] || {};


### PR DESCRIPTION
## Summary
- Remove the obsolete **Genomsnittligt mål** option from statistic filters
- Compute averages for selected data types and show them in a new top-left box in the chart
- Drop the old goal dataset/column from charts and tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a85138138c83339745dfc9fdfb6b6b