### PR TITLE
Add ability to edit and delete logged calls

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,7 +353,18 @@
         .btn-danger:hover {
             background: #c62828;
         }
-        
+
+        .btn-small {
+            padding: 0.25rem 0.5rem;
+            font-size: 0.875rem;
+        }
+
+        .call-actions {
+            display: flex;
+            gap: 0.5rem;
+            margin-top: 0.5rem;
+        }
+
         /* Stjärnbetyg */
         .star-rating {
             display: flex;
@@ -822,6 +833,7 @@
                     <div class="flex gap-2">
                         <button type="submit" class="btn btn-primary">Spara samtal</button>
                         <button type="button" class="btn btn-secondary" id="undoLastCall">Ångra senaste</button>
+                        <button type="button" class="btn btn-secondary" id="cancelEdit" style="display:none;">Avbryt</button>
                     </div>
                 </form>
             </div>
@@ -1108,6 +1120,7 @@
         let currentTab = 'samtal';
         let currentChart = null;
         let digitalToggleState = false; // false = "Tid utanför digitala", true = "Digitala"
+        let editingCallId = null;
         
         // Standardmål per pass (arbetsdag)
         const DEFAULT_GOALS = {
@@ -1359,7 +1372,16 @@
                 }
             });
         }
-        
+
+        function setStarRating(ratingName, value) {
+            const rating = document.querySelector(`.star-rating[data-rating="${ratingName}"]`);
+            if (!rating) return;
+            const stars = rating.querySelectorAll('.star');
+            const hiddenInput = document.getElementById(ratingName);
+            hiddenInput.value = value || '';
+            updateStars(stars, value || 0);
+        }
+
         // ====================
         // SAMTAL-HANTERING
         // ====================
@@ -1369,6 +1391,7 @@
             const typInputs = document.querySelectorAll('input[name="typ"]');
             const kategoriGroup = document.getElementById('kategoriGroup');
             const undoButton = document.getElementById('undoLastCall');
+            const cancelEditButton = document.getElementById('cancelEdit');
             const searchInput = document.getElementById('callSearch');
             
             // Visa/dölj kategori beroende på typ
@@ -1385,10 +1408,13 @@
             
             // Hantera formulärinlämning
             callForm.addEventListener('submit', handleCallSubmit);
-            
+
             // Ångra senaste samtal
             undoButton.addEventListener('click', undoLastCall);
-            
+
+            // Avbryt redigering
+            cancelEditButton.addEventListener('click', cancelEditCall);
+
             // Sök i samtal
             searchInput.addEventListener('input', updateRecentCalls);
             
@@ -1398,10 +1424,9 @@
         
         function handleCallSubmit(e) {
             e.preventDefault();
-            
+
             const formData = new FormData(e.target);
             const callData = {
-                id: generateUUID(),
                 typ: formData.get('typ'),
                 kategori: formData.get('kategori') || null,
                 stjarna_generellt: parseInt(formData.get('stjarna_generellt')) || null,
@@ -1409,8 +1434,7 @@
                 stjarna_insats: parseInt(formData.get('stjarna_insats')) || null,
                 vad_gick_bra: formData.get('vad_gick_bra') || '',
                 forbattra: formData.get('forbattra') || '',
-                samtalstid_min: formData.get('samtalstid_min') ? parseInt(formData.get('samtalstid_min')) : null,
-                timestamp: new Date().toISOString()
+                samtalstid_min: formData.get('samtalstid_min') ? parseInt(formData.get('samtalstid_min')) : null
             };
             
             // Validering
@@ -1424,12 +1448,28 @@
                 return;
             }
             
-            // Spara samtal
+            // Spara eller uppdatera samtal
             const calls = getLocalStorage('ksCalls', []);
-            calls.push(callData);
-            setLocalStorage('ksCalls', calls);
-            
-            showToast('Samtalet har sparats');
+
+            if (editingCallId) {
+                const index = calls.findIndex(c => c.id === editingCallId);
+                if (index !== -1) {
+                    callData.id = editingCallId;
+                    callData.timestamp = calls[index].timestamp;
+                    calls[index] = callData;
+                    setLocalStorage('ksCalls', calls);
+                    showToast('Samtalet har uppdaterats');
+                }
+                editingCallId = null;
+                document.querySelector('#callForm button[type="submit"]').textContent = 'Spara samtal';
+                document.getElementById('cancelEdit').style.display = 'none';
+            } else {
+                callData.id = generateUUID();
+                callData.timestamp = new Date().toISOString();
+                calls.push(callData);
+                setLocalStorage('ksCalls', calls);
+                showToast('Samtalet har sparats');
+            }
             
             // Återställ formulär
             e.target.reset();
@@ -1470,7 +1510,58 @@
                 updateSalesCounters();
             }
         }
-        
+
+        function startEditCall(id) {
+            const calls = getLocalStorage('ksCalls', []);
+            const call = calls.find(c => c.id === id);
+            if (!call) return;
+
+            editingCallId = id;
+
+            const typInput = document.querySelector(`input[name="typ"][value="${call.typ}"]`);
+            if (typInput) {
+                typInput.checked = true;
+                typInput.dispatchEvent(new Event('change'));
+            }
+            document.getElementById('kategori').value = call.kategori || '';
+            setStarRating('stjarna_generellt', call.stjarna_generellt);
+            setStarRating('stjarna_kund', call.stjarna_kund);
+            setStarRating('stjarna_insats', call.stjarna_insats);
+            document.getElementById('vadGickBra').value = call.vad_gick_bra;
+            document.getElementById('forbattra').value = call.forbattra;
+            document.getElementById('samtalstid').value = call.samtalstid_min || '';
+
+            document.querySelector('#callForm button[type="submit"]').textContent = 'Uppdatera samtal';
+            document.getElementById('cancelEdit').style.display = 'inline-flex';
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+
+        function cancelEditCall() {
+            editingCallId = null;
+            document.getElementById('callForm').reset();
+            resetStarRatings();
+            document.querySelector('#callForm button[type="submit"]').textContent = 'Spara samtal';
+            document.getElementById('cancelEdit').style.display = 'none';
+        }
+
+        function deleteCall(id) {
+            if (!confirm('Är du säker på att du vill ta bort detta samtal?')) return;
+            const calls = getLocalStorage('ksCalls', []);
+            const index = calls.findIndex(c => c.id === id);
+            if (index !== -1) {
+                calls.splice(index, 1);
+                setLocalStorage('ksCalls', calls);
+                showToast('Samtalet har tagits bort');
+                if (editingCallId === id) {
+                    cancelEditCall();
+                }
+                updateRecentCalls();
+                if (currentTab === 'saljmal') {
+                    updateSalesCounters();
+                }
+            }
+        }
+
         function updateRecentCalls() {
             const calls = getLocalStorage('ksCalls', []);
             const searchTerm = document.getElementById('callSearch').value.toLowerCase();
@@ -1516,11 +1607,22 @@
                         </div>
                         ${call.vad_gick_bra ? `<div style="margin-bottom: 0.25rem;"><small><strong>Bra:</strong> ${call.vad_gick_bra}</small></div>` : ''}
                         ${call.forbattra ? `<div><small><strong>Förbättra:</strong> ${call.forbattra}</small></div>` : ''}
+                        <div class="call-actions">
+                            <button class="btn btn-secondary btn-small edit-call" data-id="${call.id}">Ändra</button>
+                            <button class="btn btn-danger btn-small delete-call" data-id="${call.id}">Ta bort</button>
+                        </div>
                     </div>
                 `;
             }).join('');
-            
+
             container.innerHTML = html;
+
+            container.querySelectorAll('.edit-call').forEach(btn => {
+                btn.addEventListener('click', () => startEditCall(btn.dataset.id));
+            });
+            container.querySelectorAll('.delete-call').forEach(btn => {
+                btn.addEventListener('click', () => deleteCall(btn.dataset.id));
+            });
         }
         
         // ====================


### PR DESCRIPTION
## Summary
- allow editing existing calls and deleting specific entries without clearing IndexedDB data
- add cancel-edit flow and small action buttons in recent calls list
- introduce helper for programmatically setting star ratings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac131e6be88333a62218a93543262f