### PR TITLE
Keep tabs visible while scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,8 @@
             --radius: 12px;
             --radius-small: 8px;
             --transition: all 0.3s ease;
+            --header-height: 73px;
+            --nav-tabs-height: 56px;
         }
         
         [data-theme="dark"] {
@@ -200,7 +202,7 @@
             background: var(--color-surface);
             border-bottom: 1px solid var(--color-border);
             position: sticky;
-            top: 73px;
+            top: var(--header-height);
             z-index: 99;
         }
         
@@ -322,6 +324,10 @@
             gap: 1rem;
             border-bottom: 1px solid var(--color-border);
             margin-bottom: 1rem;
+            background: var(--color-surface);
+            position: sticky;
+            top: calc(var(--header-height) + var(--nav-tabs-height));
+            z-index: 98;
         }
         
         /* Kort-komponenter */


### PR DESCRIPTION
## Summary
- Keep Logg/Arbetsstöd navigation bar fixed below the header using CSS variables
- Make submenus (Samtal, Säljmål, Statistik, Skriv ärende) sticky below main tabs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1590d44588333a91c729157494176