### PR TITLE
Ensure tab switches start at top

### DIFF
--- a/index.html
+++ b/index.html
@@ -1556,6 +1556,9 @@
                 const content = document.getElementById(`content-${tabId}`);
                 if (content) content.classList.add('active');
 
+                // Ensure the page starts at the top when switching tabs
+                window.scrollTo(0, 0);
+
                 currentTab = tabId;
 
                 if (tabId === 'arbetsstod') {
@@ -1596,6 +1599,9 @@
                 document.getElementById(`content-${id}`).classList.add('active');
                 currentLoggTab = id;
 
+                // Always scroll to top when changing subtabs
+                window.scrollTo(0, 0);
+
                 if (id === 'samtal') {
                     updateRecentCalls();
                     updateAllCalls();
@@ -1621,6 +1627,8 @@
                     contents.forEach(c => c.classList.remove('active'));
                     button.classList.add('active');
                     document.getElementById(`call-${target}`).classList.add('active');
+                    // Scroll to top when switching call subtabs
+                    window.scrollTo(0, 0);
                     if (target === 'recent') {
                         updateRecentCalls();
                     } else {


### PR DESCRIPTION
## Summary
- Scroll window to top when switching main tabs
- Scroll to top when changing log and call subtabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b15cf752608333a0381ddede764b7e